### PR TITLE
Adds new light ReadyToInstall variant - prevents deserialization.

### DIFF
--- a/src/resource/light.rs
+++ b/src/resource/light.rs
@@ -105,6 +105,8 @@ pub enum SoftwareUpdateState {
     NoUpdates,
     /// Device cannot be updated.
     NotUpdatable,
+    /// Device is ready to install new updates.
+    ReadyToInstall,
     // TODO: Add missing variants for states (https://github.com/yuqio/huelib-rs/issues/1)
 }
 


### PR DESCRIPTION
I'm unable to deserialize due to this state which is missing for the SoftwareUpdateState enum.

Relevant error:

```
Failed to get lights: Failed to parse json content: unknown variant `readytoinstall`, expected `noupdates` or `notupdatable`
```

Referencing this issue: https://github.com/yuqio/huelib-rs/issues/1