### PR TITLE
Add missing Transferring sw update state

### DIFF
--- a/src/resource/light.rs
+++ b/src/resource/light.rs
@@ -105,6 +105,8 @@ pub enum SoftwareUpdateState {
     NoUpdates,
     /// Device cannot be updated.
     NotUpdatable,
+    /// Device is downloading new updates.
+    Transferring,
     /// Device is ready to install new updates.
     ReadyToInstall,
     // TODO: Add missing variants for states (https://github.com/yuqio/huelib-rs/issues/1)


### PR DESCRIPTION
Deserialization fails if one of the lights is in "transferring" state.