### PR TITLE
Try to support the Hue v1 bridge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ mime = { version = "0.3.16", optional = true }
 
 [features]
 upnp-description = ["serde-xml-rs", "url", "uuid", "mime"]
+old-api = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! - `upnp-description`: Adds support for accessing the UPnP description of a bridge. See the
 //! [`bridge::Description`] struct for more information.
 //! - `old-api`: Minimal effort support for older api versions. Useful for users of the no longer
-//! supported Hue v1 bridge. This lowers the supported API version to `1.16` not all features 
+//! supported Hue v1 bridge. This lowers the supported API version to `1.16` not all features
 //! are guarenteed to work.
 //!
 //! # Connecting to a bridge

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! - `upnp-description`: Adds support for accessing the UPnP description of a bridge. See the
 //! [`bridge::Description`] struct for more information.
-//! - `old-api`: minimal effort support for older api versions. Usefull for users of the no longer
+//! - `old-api`: Minimal effort support for older api versions. Useful for users of the no longer
 //! supported Hue v1 bridge. This lowers the supported API version to `1.16` not all features 
 //! are guarenteed to work.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 //!
 //! - `upnp-description`: Adds support for accessing the UPnP description of a bridge. See the
 //! [`bridge::Description`] struct for more information.
+//! - `old-api`: minimal effort support for older api versions. Usefull for users of the no longer
+//! supported Hue v1 bridge. This lowers the supported API version to `1.16` not all features 
+//! are guarenteed to work.
 //!
 //! # Connecting to a bridge
 //!

--- a/src/resource/light.rs
+++ b/src/resource/light.rs
@@ -38,11 +38,11 @@ pub struct Light {
     pub software_version: String,
     /// Information about software updates of the light.
     #[serde(rename = "swupdate")]
-    pub software_update: SoftwareUpdate,
+    pub software_update: Option<SoftwareUpdate>,
     /// Configuration of the light.
-    pub config: Config,
+    pub config: Option<Config>,
     /// Capabilities of the light.
-    pub capabilities: Capabilities,
+    pub capabilities: Option<Capabilities>,
 }
 
 impl Light {

--- a/src/resource/light.rs
+++ b/src/resource/light.rs
@@ -37,12 +37,15 @@ pub struct Light {
     #[serde(rename = "swversion")]
     pub software_version: String,
     /// Information about software updates of the light.
+    #[cfg(not(feature = "old-api"))]
     #[serde(rename = "swupdate")]
-    pub software_update: Option<SoftwareUpdate>,
+    pub software_update: SoftwareUpdate,
     /// Configuration of the light.
-    pub config: Option<Config>,
+    #[cfg(not(feature = "old-api"))]
+    pub config: Config,
     /// Capabilities of the light.
-    pub capabilities: Option<Capabilities>,
+    #[cfg(not(feature = "old-api"))]
+    pub capabilities: Capabilities,
 }
 
 impl Light {


### PR DESCRIPTION
I ran into a deserialisation error when getting all lights on a Hue v1 bridge. The v1 bridge replies miss the fields: `swupdate`, `config` and `capabilities` in the _Light struct_. I switched these to Options and now it works fine. 

The type change in the _Light struct_ did not cause any compilation errors or warnings, therefore these fields are not used anywhere in the library. A good alternative would be to attribute them with [skip](https://serde.rs/field-attrs.html#skip). I chose to change the type to Option as that is the smallest change and I do not know whether you plan to use these fields later.