### PR TITLE
Fix for TV is in the group list

### DIFF
--- a/src/resource/group.rs
+++ b/src/resource/group.rs
@@ -151,7 +151,8 @@ pub enum Class {
     Staircase,
     Storage,
     Studio,
-    TV,
+    #[serde(rename = "TV")]
+    Tv,
     Terrace,
     Toilet,
     #[serde(rename = "Top floor")]
@@ -383,23 +384,6 @@ mod tests {
             "class": "Office"
         });
         assert_eq!(modifier_json, expected_json);
-    }
-
-
-    #[test]
-    fn deserialize_attribute_modifier_tv() {
-
-        let modifier_json_tv = json!({
-            "name": "test",
-            "lights": ["1", "2"],
-            "sensors": ["3"],
-            "class": "TV"
-        });
-
-        let modifier: AttributeModifier  = serde_json::from_value(modifier_json_tv).unwrap();
-
-        let modifier_class_string = format!("{:?}", modifier.class.unwrap());
-        assert_eq!(modifier_class_string, "TV");
     }
 
     #[test]

--- a/src/resource/group.rs
+++ b/src/resource/group.rs
@@ -214,7 +214,7 @@ impl resource::Creator for Creator {
 }
 
 /// Struct for modifying group attributes.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Setters, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Setters)]
 #[setters(strip_option, prefix = "with_")]
 pub struct AttributeModifier {
     /// Sets the name of the group.

--- a/src/resource/group.rs
+++ b/src/resource/group.rs
@@ -151,7 +151,7 @@ pub enum Class {
     Staircase,
     Storage,
     Studio,
-    Tv,
+    TV,
     Terrace,
     Toilet,
     #[serde(rename = "Top floor")]
@@ -213,7 +213,7 @@ impl resource::Creator for Creator {
 }
 
 /// Struct for modifying group attributes.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Setters)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Setters, Deserialize)]
 #[setters(strip_option, prefix = "with_")]
 pub struct AttributeModifier {
     /// Sets the name of the group.
@@ -383,6 +383,23 @@ mod tests {
             "class": "Office"
         });
         assert_eq!(modifier_json, expected_json);
+    }
+
+
+    #[test]
+    fn deserialize_attribute_modifier_tv() {
+
+        let modifier_json_tv = json!({
+            "name": "test",
+            "lights": ["1", "2"],
+            "sensors": ["3"],
+            "class": "TV"
+        });
+
+        let modifier: AttributeModifier  = serde_json::from_value(modifier_json_tv).unwrap();
+
+        let modifier_class_string = format!("{:?}", modifier.class.unwrap());
+        assert_eq!(modifier_class_string, "TV");
     }
 
     #[test]


### PR DESCRIPTION
Current version isn't able to deserialize the goups list, if the list contains a class with TV.

A partly real response from the hue bridge api
`"4": {
    "name": "Fernseher",
    "lights": [
      "6"
    ],
    "sensors": [],
    "type": "Entertainment",
    "state": {
      "all_on": true,
      "any_on": true
    },
    "recycle": false,
    "class": "TV",
    "stream": {
      "proxymode": "auto",
      "proxynode": "/bridge",
      "active": false,
      "owner": null`

"TV" in class is completely in upper case and not "Tv". With "Tv" deserialization error is thrown. 
The pr should fix this.