### PR TITLE
Add deserialize option for static state modifier

### DIFF
--- a/src/resource/light.rs
+++ b/src/resource/light.rs
@@ -312,6 +312,22 @@ pub struct StateModifier {
     pub transition_time: Option<u16>,
 }
 
+impl From<StaticStateModifier> for StateModifier {
+    fn from(value: StaticStateModifier) -> Self {
+        Self {
+            on: value.on,
+            brightness: value.brightness.map(Adjust::Override),
+            hue: value.hue.map(Adjust::Override),
+            saturation: value.saturation.map(Adjust::Override),
+            color_space_coordinates: value.color_space_coordinates.map(Adjust::Override),
+            color_temperature: value.color_temperature.map(Adjust::Override),
+            alert: Some(Alert::None),
+            effect: value.effect,
+            transition_time: value.transition_time
+        }
+    }
+}
+
 impl StateModifier {
     /// Creates a new [`StateModifier`].
     pub fn new() -> Self {

--- a/src/resource/light.rs
+++ b/src/resource/light.rs
@@ -226,7 +226,7 @@ impl resource::Modifier for AttributeModifier {
 ///
 /// [`scene::Modifier`]: super::scene::Modifier
 /// [`scene::Creator`]: super::scene::Creator
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Setters)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Setters, Deserialize)]
 #[setters(strip_option, prefix = "with_")]
 pub struct StaticStateModifier {
     /// Turns the light on or off.


### PR DESCRIPTION
I am building something using this library and have a need for a struct similar to the state structs provided by this lib but something that implements deserialize. 

I think this is a small change, that might be pretty helpful for anyone trying load modifiers from serialized files. 

This also adds support for a simplistic translation from a `StaticStateModifier` to a `StateModifier`